### PR TITLE
add SoundEffectPlayer3D

### DIFF
--- a/components/interact_notify.gd
+++ b/components/interact_notify.gd
@@ -1,5 +1,7 @@
 extends Node3D
 
+signal talked_to
+
 @export var npc_id = ""
 
 @onready var interactable_area_3d: InteractableArea3D = %InteractableArea3D
@@ -16,4 +18,5 @@ func _on_quest_change():
 
 func _on_interacted(player: Player):
 	GlobalSignalBus.talked_to.emit(npc_id)
+	talked_to.emit()
 	visible = false

--- a/components/sound_player_3d/sound_player_3d.gd
+++ b/components/sound_player_3d/sound_player_3d.gd
@@ -1,0 +1,109 @@
+extends AudioStreamPlayer3D
+class_name SoundPlayer3D
+
+@export_group("Start SFX condition")
+@export var start_callable_node: Node = null
+@export var start_signal_name: StringName = ""
+@export_group("Stop SFX condition")
+@export var stop_callable_node: Node = null
+@export var stop_signal_name: StringName = ""
+@export_group("Global SFX condition")
+@export var g_start_signal_name: StringName = ""
+@export var g_stop_signal_name: StringName = ""
+
+@onready var global_signal_bus: Node = get_tree().get_root().get_node("GlobalSignalBus")
+
+var try_connect_start_result: int = FAILED
+var try_connect_stop_result: int = FAILED
+var try_connect_g_start_result: int = FAILED
+var try_connect_g_stop_result: int = FAILED
+
+# extends: https://docs.godotengine.org/en/stable/classes/class_@globalscope.html#enum-globalscope-error
+enum TryConnectError {
+    INSTANCE_INVALID = 49,
+    NO_SIGNAL_NAME = 50,
+    NO_MATCHING_SIGNAL_NAME = 51,
+}
+    
+
+func _ready() -> void:
+    try_connect_stop_signal()
+    try_connect_start_signal()
+    try_connect_global_start_signal()
+    try_connect_global_stop_signal()
+
+
+func try_connect_stop_signal() -> int:
+    if not is_instance_valid(stop_callable_node):
+        try_connect_stop_result = TryConnectError.INSTANCE_INVALID
+        return TryConnectError.INSTANCE_INVALID
+        
+    if stop_signal_name == "":
+        try_connect_stop_result = TryConnectError.NO_SIGNAL_NAME
+        return TryConnectError.NO_SIGNAL_NAME
+        
+    if not stop_callable_node.has_signal(stop_signal_name):
+        try_connect_stop_result = TryConnectError.NO_MATCHING_SIGNAL_NAME
+        return TryConnectError.NO_MATCHING_SIGNAL_NAME
+    
+    try_connect_stop_result = stop_callable_node.connect(stop_signal_name, _on_stop)    
+    return try_connect_stop_result 
+    
+    
+func try_connect_start_signal() -> bool:    
+    if not is_instance_valid(start_callable_node):
+        try_connect_start_result = TryConnectError.INSTANCE_INVALID
+        return TryConnectError.INSTANCE_INVALID
+        
+    if start_signal_name == "":
+        try_connect_start_result = TryConnectError.NO_SIGNAL_NAME
+        return TryConnectError.NO_SIGNAL_NAME
+        
+    if not start_callable_node.has_signal(start_signal_name):
+        try_connect_start_result = TryConnectError.NO_MATCHING_SIGNAL_NAME
+        return TryConnectError.NO_MATCHING_SIGNAL_NAME
+        
+    try_connect_start_result = start_callable_node.connect(start_signal_name, _on_start)
+    return try_connect_start_result 
+
+
+func try_connect_global_start_signal() -> int:
+    if not is_instance_valid(global_signal_bus):
+        try_connect_g_start_result = TryConnectError.INSTANCE_INVALID
+        return TryConnectError.INSTANCE_INVALID
+        
+    if g_start_signal_name == "":
+        try_connect_g_start_result = TryConnectError.NO_SIGNAL_NAME
+        return TryConnectError.NO_SIGNAL_NAME
+        
+    if not global_signal_bus.has_signal(g_start_signal_name):
+        try_connect_g_start_result = TryConnectError.NO_MATCHING_SIGNAL_NAME
+        return TryConnectError.NO_MATCHING_SIGNAL_NAME
+    
+    try_connect_g_start_result = global_signal_bus.connect(g_start_signal_name, _on_start)
+    return try_connect_g_start_result 
+
+
+func try_connect_global_stop_signal() -> int:
+    if not is_instance_valid(global_signal_bus):
+        try_connect_g_stop_result = TryConnectError.INSTANCE_INVALID
+        return TryConnectError.INSTANCE_INVALID
+    
+    if g_start_signal_name == "":
+        try_connect_g_stop_result = TryConnectError.NO_SIGNAL_NAME
+        return TryConnectError.NO_SIGNAL_NAME
+    
+    if not global_signal_bus.has_signal(g_stop_signal_name):
+        try_connect_g_stop_result = TryConnectError.NO_MATCHING_SIGNAL_NAME
+        return TryConnectError.NO_MATCHING_SIGNAL_NAME
+        
+    try_connect_g_stop_result = global_signal_bus.connect(g_stop_signal_name, _on_stop)
+    return try_connect_g_stop_result 
+
+
+func _on_start() -> void:
+    play()
+    
+
+func _on_stop() -> void:
+    stop()

--- a/components/sound_player_3d/sound_player_3d.gd
+++ b/components/sound_player_3d/sound_player_3d.gd
@@ -101,9 +101,13 @@ func try_connect_global_stop_signal() -> int:
     return try_connect_g_stop_result 
 
 
-func _on_start() -> void:
+func _on_start(args = null) -> void:
+    if args != null:
+        push_warning("args present: ", args)
     play()
-    
 
-func _on_stop() -> void:
+
+func _on_stop(args) -> void:
+    if args != null:
+        push_warning("args present: ", args)
     stop()

--- a/components/sound_player_3d/sound_player_3d.gd.uid
+++ b/components/sound_player_3d/sound_player_3d.gd.uid
@@ -1,0 +1,1 @@
+uid://bqaasgleubvyc

--- a/design/audio-systems/spatial-sfx.excalidraw.json
+++ b/design/audio-systems/spatial-sfx.excalidraw.json
@@ -1,0 +1,51 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://marketplace.visualstudio.com/items?itemName=pomdtr.excalidraw-editor",
+  "elements": [
+    {
+      "id": "Jf-G8MYg2wNpiyBJwl1ur",
+      "type": "text",
+      "x": -74.89584350585938,
+      "y": 192.78643798828125,
+      "width": 1013.0390014648438,
+      "height": 225,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a2",
+      "roundness": null,
+      "seed": 2110820727,
+      "version": 990,
+      "versionNonce": 235169817,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1746666240736,
+      "link": null,
+      "locked": false,
+      "text": "Is a 3D sound effect player triggered by an event\nExtends AudioStreamPlayer3D\ndesigner can add 'SoundEffectPlayer3D' to any scene using \"add child node\"\ndesigner can select a node that has signals to subscribe to in the available tree scope\ndesigner can subscribe the player to an event signal using signal string name\ndesigner can configure the sound effect to be played\nwhen 'SoundEffectPlayer3D' receives subscribed signal it emits sound effect\ndesigner may subscribe the player to an explicit stop signal\nwhen 'SoundEffectPlayer3D' receives subscribed 'stop' signal the sound effect immediately stops playing",
+      "fontSize": 20,
+      "fontFamily": 5,
+      "textAlign": "left",
+      "verticalAlign": "top",
+      "containerId": null,
+      "originalText": "Is a 3D sound effect player triggered by an event\nExtends AudioStreamPlayer3D\ndesigner can add 'SoundEffectPlayer3D' to any scene using \"add child node\"\ndesigner can select a node that has signals to subscribe to in the available tree scope\ndesigner can subscribe the player to an event signal using signal string name\ndesigner can configure the sound effect to be played\nwhen 'SoundEffectPlayer3D' receives subscribed signal it emits sound effect\ndesigner may subscribe the player to an explicit stop signal\nwhen 'SoundEffectPlayer3D' receives subscribed 'stop' signal the sound effect immediately stops playing",
+      "autoResize": true,
+      "lineHeight": 1.25
+    }
+  ],
+  "appState": {
+    "gridSize": 20,
+    "gridStep": 5,
+    "gridModeEnabled": false,
+    "viewBackgroundColor": "#ffffff"
+  },
+  "files": {}
+}

--- a/test/scenarios/test_sound_player_3d/sp3d_test_level.gd
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_level.gd
@@ -1,0 +1,14 @@
+extends Node3D
+
+@export var sound_player_3d: AudioStreamPlayer3D
+
+func _ready():
+    
+    var callable = Callable(sound_player_3d, "_on_start")
+    print("Object Instance: ", SoundPlayer3D)
+    print("callable: ", callable)
+    print("signal name: ", sound_player_3d.g_start_signal_name)
+    print("has_method: ", sound_player_3d.has_method("_on_start"))
+    print("try_connect_g_start_esult: ", sound_player_3d.try_connect_g_start_result)
+    print("is_connected: ", sound_player_3d.global_signal_bus.is_connected(sound_player_3d.g_start_signal_name, callable))
+    assert(sound_player_3d.global_signal_bus.is_connected(sound_player_3d.g_start_signal_name, callable))

--- a/test/scenarios/test_sound_player_3d/sp3d_test_level.gd
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_level.gd
@@ -1,7 +1,6 @@
 extends Node3D
 
 @export var sound_player_3d: AudioStreamPlayer3D
-
 func _ready():
     
     var callable = Callable(sound_player_3d, "_on_start")
@@ -9,6 +8,6 @@ func _ready():
     print("callable: ", callable)
     print("signal name: ", sound_player_3d.g_start_signal_name)
     print("has_method: ", sound_player_3d.has_method("_on_start"))
-    print("try_connect_g_start_esult: ", sound_player_3d.try_connect_g_start_result)
+    print("try_connect_g_start_result: ", sound_player_3d.try_connect_g_start_result)
     print("is_connected: ", sound_player_3d.global_signal_bus.is_connected(sound_player_3d.g_start_signal_name, callable))
     assert(sound_player_3d.global_signal_bus.is_connected(sound_player_3d.g_start_signal_name, callable))

--- a/test/scenarios/test_sound_player_3d/sp3d_test_level.gd.uid
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_level.gd.uid
@@ -1,0 +1,1 @@
+uid://cs3aqrqmxkfj0

--- a/test/scenarios/test_sound_player_3d/sp3d_test_level.tscn
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_level.tscn
@@ -1,0 +1,146 @@
+[gd_scene load_steps=13 format=3 uid="uid://8oq1ak8luadb"]
+
+[ext_resource type="Script" uid="uid://cs3aqrqmxkfj0" path="res://test/scenarios/test_sound_player_3d/sp3d_test_level.gd" id="1_i8fqo"]
+[ext_resource type="PackedScene" uid="uid://pgg1u7bhxcxf" path="res://components/environment/environment.tscn" id="1_w573e"]
+[ext_resource type="Script" uid="uid://bd046eokvcnu2" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="2_i8fqo"]
+[ext_resource type="PackedScene" uid="uid://4uor5nnaruka" path="res://common/ui/hud/hud_canvas_layer.tscn" id="3_ytv67"]
+[ext_resource type="PackedScene" uid="uid://co1kf3n1i47iy" path="res://actors/player_character/player.tscn" id="4_4dkwq"]
+[ext_resource type="PackedScene" uid="uid://nwbkxvaa2518" path="res://actors/npcs/trin/npc_trin.tscn" id="5_lwodk"]
+[ext_resource type="Script" uid="uid://bqaasgleubvyc" path="res://components/sound_player_3d/sound_player_3d.gd" id="6_21ko6"]
+[ext_resource type="Material" uid="uid://cvlpfft4tnlr" path="res://materials/PrototypePavement.tres" id="7_uflf2"]
+
+[sub_resource type="NavigationMesh" id="NavigationMesh_ntgmv"]
+vertices = PackedVector3Array(-49.5, 0.2, -49.5, -49.5, 0.2, 49.5, 49.5, 0.2, 49.5, 49.5, 0.2, -49.5)
+polygons = [PackedInt32Array(3, 2, 0), PackedInt32Array(0, 2, 1)]
+cell_height = 0.1
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_pdt6n"]
+albedo_color = Color(0.215902, 0.215902, 0.215902, 1)
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_qst22"]
+size = Vector2(150, 150)
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_ppxl0"]
+size = Vector2(15, 15)
+
+[node name="LevelMvp" type="Node3D" node_paths=PackedStringArray("sound_player_3d")]
+editor_description = "1. Wake up at home
+    1. You start outside the front door.
+2. Go to your home’s roof to harvest crops from raised bed → add food to inventory
+    1. when you are next to the door, it shows “enter” as part of interact
+    2. The food is ready to harvest. 
+        1. There is a raised bed, it can have plants on it. The plants can be in different growth states (seedling, growing, mature). When you “interact”, when it is mature, you harvest it.
+    3. click to harvest
+    4. If it’s a single-harvest plant, bed gets reset to empty.
+    5. If it’s a recurring plant, it goes back to being earlier growth. x game hours yield wait period.
+3. Collect water and soil from the compost bin and rain barrel on your roof → add to inventory
+    1. Click on rain barrel, adds x water to your inventory.
+        1. The rain barrel can hold water. When you interact with it, you collect water from it. (Interact, collect)
+    2. Click on compost bin to add x compost to inventory
+        1. You can collect from an object while interacting with it (collect on interact). There is a compost bin structure with this interact to collect ability. When you interact with the compost bin, your resource count in the UI increments by 1
+4. Walk to community hub
+    1. Donate food
+        1. Click on food stand (interact)
+        2. Remove food from inventory
+        3. Increase community health by +1
+    2. Collect waste
+        1. Click on waste reciprocal 
+        2. Add waste to inventory (based on how much food was donated day before or last interaction)
+        3. Add seeds to inventory (based on how much food was donated day before or last interaction)
+            
+            ![ChatGPT Image Apr 27, 2025, 06_37_39 PM.png](attachment:d87d3a4e-59d0-4afe-b033-99370472a271:ChatGPT_Image_Apr_27_2025_06_37_39_PM.png)
+            
+    3. View community bulletin board
+        1. There’s an indicator of a pending community note on the community board
+        2. Click on community board
+        3. View new note that asks for structure to be built
+        4. Structure “unlocks” in build mode
+        5. Structure added to quest with number of materials needed
+    
+    [Create a community board](https://www.notion.so/Create-a-community-board-1e2e3beb843f80518e14e1772c19e993?pvs=21)
+    
+    Build a solar panel
+    
+    1. Check **donation chest**
+        1. Add materials to inventory
+    
+5. Go to neighbor’s roof to harvest crops —> add food to inventory
+    1. The food is ready to harvest.
+    2. click to harvest
+    3. If it’s a single-harvest plant, bed gets reset to empty.
+    4. If it’s a recurring plant, it goes back to being earlier growth. x game hours yield wait period.
+6. Add waste to compost bin on neighbor’s roof
+    1. Click on compost bin
+    2. Subtract waste from inventory 
+    3. Set timer
+    4. Add soil to compost bin after X real-time minutes 
+7. Plant new seeds in recently harvested raised bed with compost, water, and seeds 
+    1. Click raised bed/garden
+    2. Simple version: automatically subtract 1 compost, 1 water, 1 seed from inventory
+    3. Set timer
+    4. Add seedling after x real-time minutes
+    5. Add plant and make harvestable after x real-time minutes
+8. Build
+    1. Option 1: deliver materials to workshop, select structure you want to build from build menu) get structure in inventory or toggle it active or something in build menu (this may need to be on a time delay for pacing issues)
+    2. Option 2: deliver materials to your choice of build site, construction in progress asset appears, after x in-time the structure appears
+9. ~~Talk to another NPC → get new Quest~~
+    1. ~~NPC gives you a quest~~
+    2. ~~Add quest to quest menu (retrieve book for Mister)~~
+10. ~~Walk around neighborhood to find book (narratively, I don’t know how this works yet…if you are finding things in the environment or other npcs)~~
+11. Return home for bed (ends day) OR we hit 10PM in-game and we do some sort of fade to black"
+script = ExtResource("1_i8fqo")
+sound_player_3d = NodePath("Trin/SoundPlayer3D")
+
+[node name="Environment" parent="." instance=ExtResource("1_w573e")]
+day_length_in_game_hours = 14.0
+
+[node name="MainCamera3D" type="Camera3D" parent="."]
+unique_name_in_owner = true
+physics_interpolation_mode = 1
+transform = Transform3D(0.999999, 0, 0, 0, 0.866022, 0.499996, 0, -0.499998, 0.866019, -3.82898, 2.86358, 18.1236)
+
+[node name="PhantomCameraHost" type="Node" parent="MainCamera3D"]
+process_priority = 300
+process_physics_priority = 300
+script = ExtResource("2_i8fqo")
+
+[node name="NavigationRegion3D" type="NavigationRegion3D" parent="."]
+navigation_mesh = SubResource("NavigationMesh_ntgmv")
+
+[node name="Terrain" type="Node3D" parent="NavigationRegion3D"]
+
+[node name="CSGBox3D" type="CSGBox3D" parent="NavigationRegion3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0)
+visible = false
+use_collision = true
+collision_layer = 2
+size = Vector3(100, 1, 100)
+
+[node name="NavigationObstacle3D" type="NavigationObstacle3D" parent="NavigationRegion3D"]
+carve_navigation_mesh = true
+
+[node name="HUDCanvasLayer" parent="." instance=ExtResource("3_ytv67")]
+layer = 5
+
+[node name="Player" parent="." instance=ExtResource("4_4dkwq")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.82898, 1.66893e-06, 15.0925)
+
+[node name="Trin" parent="." instance=ExtResource("5_lwodk")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00170803, 0.00154209, 12.5012)
+
+[node name="SoundPlayer3D" type="AudioStreamPlayer3D" parent="Trin"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2705, 0)
+script = ExtResource("6_21ko6")
+g_start_signal_name = &"talked_to"
+metadata/_custom_type_script = "uid://bqaasgleubvyc"
+
+[node name="Ground" type="MeshInstance3D" parent="."]
+transform = Transform3D(0.997527, 0, 0, 0, 0.997527, 0, 0, 0, 0.863667, -0.754, 0, -4.342)
+material_override = SubResource("StandardMaterial3D_pdt6n")
+mesh = SubResource("PlaneMesh_qst22")
+
+[node name="Pavement6" type="MeshInstance3D" parent="Ground"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.716528, 0.00999809, 6.73156)
+material_override = ExtResource("7_uflf2")
+mesh = SubResource("PlaneMesh_ppxl0")
+skeleton = NodePath("")

--- a/test/scenarios/test_sound_player_3d/sp3d_test_level.tscn
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://8oq1ak8luadb"]
+[gd_scene load_steps=14 format=3 uid="uid://8oq1ak8luadb"]
 
 [ext_resource type="Script" uid="uid://cs3aqrqmxkfj0" path="res://test/scenarios/test_sound_player_3d/sp3d_test_level.gd" id="1_i8fqo"]
 [ext_resource type="PackedScene" uid="uid://pgg1u7bhxcxf" path="res://components/environment/environment.tscn" id="1_w573e"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://nwbkxvaa2518" path="res://actors/npcs/trin/npc_trin.tscn" id="5_lwodk"]
 [ext_resource type="Script" uid="uid://bqaasgleubvyc" path="res://components/sound_player_3d/sound_player_3d.gd" id="6_21ko6"]
 [ext_resource type="Material" uid="uid://cvlpfft4tnlr" path="res://materials/PrototypePavement.tres" id="7_uflf2"]
+[ext_resource type="AudioStream" uid="uid://bctbx2ln5apr5" path="res://common/audio/sfx/ui/aud_ui_load.wav" id="7_ytv67"]
 
 [sub_resource type="NavigationMesh" id="NavigationMesh_ntgmv"]
 vertices = PackedVector3Array(-49.5, 0.2, -49.5, -49.5, 0.2, 49.5, 49.5, 0.2, 49.5, 49.5, 0.2, -49.5)
@@ -130,6 +131,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00170803, 0.00154209, 12.5
 
 [node name="SoundPlayer3D" type="AudioStreamPlayer3D" parent="Trin"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2705, 0)
+stream = ExtResource("7_ytv67")
 script = ExtResource("6_21ko6")
 g_start_signal_name = &"talked_to"
 metadata/_custom_type_script = "uid://bqaasgleubvyc"

--- a/test/scenarios/test_sound_player_3d/sp3d_test_level.tscn
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_level.tscn
@@ -5,10 +5,10 @@
 [ext_resource type="Script" uid="uid://bd046eokvcnu2" path="res://addons/phantom_camera/scripts/phantom_camera_host/phantom_camera_host.gd" id="2_i8fqo"]
 [ext_resource type="PackedScene" uid="uid://4uor5nnaruka" path="res://common/ui/hud/hud_canvas_layer.tscn" id="3_ytv67"]
 [ext_resource type="PackedScene" uid="uid://co1kf3n1i47iy" path="res://actors/player_character/player.tscn" id="4_4dkwq"]
-[ext_resource type="PackedScene" uid="uid://nwbkxvaa2518" path="res://actors/npcs/trin/npc_trin.tscn" id="5_lwodk"]
 [ext_resource type="Script" uid="uid://bqaasgleubvyc" path="res://components/sound_player_3d/sound_player_3d.gd" id="6_21ko6"]
+[ext_resource type="PackedScene" uid="uid://ilatnxm00qsl" path="res://test/scenarios/test_sound_player_3d/sp3d_test_npc_trin.tscn" id="6_ytv67"]
+[ext_resource type="AudioStream" uid="uid://drtpl1axb4fiw" path="res://common/audio/sfx/player/jump/jump3.wav" id="7_4dkwq"]
 [ext_resource type="Material" uid="uid://cvlpfft4tnlr" path="res://materials/PrototypePavement.tres" id="7_uflf2"]
-[ext_resource type="AudioStream" uid="uid://bctbx2ln5apr5" path="res://common/audio/sfx/ui/aud_ui_load.wav" id="7_ytv67"]
 
 [sub_resource type="NavigationMesh" id="NavigationMesh_ntgmv"]
 vertices = PackedVector3Array(-49.5, 0.2, -49.5, -49.5, 0.2, 49.5, 49.5, 0.2, 49.5, 49.5, 0.2, -49.5)
@@ -90,7 +90,7 @@ editor_description = "1. Wake up at home
 10. ~~Walk around neighborhood to find book (narratively, I don’t know how this works yet…if you are finding things in the environment or other npcs)~~
 11. Return home for bed (ends day) OR we hit 10PM in-game and we do some sort of fade to black"
 script = ExtResource("1_i8fqo")
-sound_player_3d = NodePath("Trin/SoundPlayer3D")
+sound_player_3d = NodePath("Trin/GlobalSoundPlayer3D2")
 
 [node name="Environment" parent="." instance=ExtResource("1_w573e")]
 day_length_in_game_hours = 14.0
@@ -126,12 +126,10 @@ layer = 5
 [node name="Player" parent="." instance=ExtResource("4_4dkwq")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.82898, 1.66893e-06, 15.0925)
 
-[node name="Trin" parent="." instance=ExtResource("5_lwodk")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00170803, 0.00154209, 12.5012)
+[node name="Trin" parent="." instance=ExtResource("6_ytv67")]
 
-[node name="SoundPlayer3D" type="AudioStreamPlayer3D" parent="Trin"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.2705, 0)
-stream = ExtResource("7_ytv67")
+[node name="GlobalSoundPlayer3D2" type="AudioStreamPlayer3D" parent="Trin"]
+stream = ExtResource("7_4dkwq")
 script = ExtResource("6_21ko6")
 g_start_signal_name = &"talked_to"
 metadata/_custom_type_script = "uid://bqaasgleubvyc"

--- a/test/scenarios/test_sound_player_3d/sp3d_test_npc.gd
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_npc.gd
@@ -1,0 +1,15 @@
+extends Node3D
+
+@export var sound_player_3d: AudioStreamPlayer3D
+@export var signal_node: Node
+
+func _ready():
+    
+    var callable = Callable(sound_player_3d, "_on_start")
+    print("Object Instance: ", SoundPlayer3D)
+    print("callable: ", callable)
+    print("signal name: ", sound_player_3d.start_signal_name)
+    print("has_method: ", sound_player_3d.has_method("_on_start"))
+    print("try_connect_start_result: ", sound_player_3d.try_connect_start_result)
+    print("is_connected: ", signal_node.is_connected(sound_player_3d.start_signal_name, callable))
+    assert(signal_node.is_connected(sound_player_3d.start_signal_name, callable))

--- a/test/scenarios/test_sound_player_3d/sp3d_test_npc.gd.uid
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_npc.gd.uid
@@ -1,0 +1,1 @@
+uid://cmt728botv4gf

--- a/test/scenarios/test_sound_player_3d/sp3d_test_npc_trin.tscn
+++ b/test/scenarios/test_sound_player_3d/sp3d_test_npc_trin.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=7 format=3 uid="uid://ilatnxm00qsl"]
+
+[ext_resource type="PackedScene" uid="uid://dbiodotokwvrn" path="res://actors/npcs/npc_base.tscn" id="1_c4qox"]
+[ext_resource type="PackedScene" uid="uid://cjqq7gkmrh6v7" path="res://assets/3d/people/trin/tweenbase00.fbx" id="2_1jpor"]
+[ext_resource type="Script" uid="uid://cmt728botv4gf" path="res://test/scenarios/test_sound_player_3d/sp3d_test_npc.gd" id="2_rrvrm"]
+[ext_resource type="PackedScene" uid="uid://byfoxs7fp3xet" path="res://components/interact_notify.tscn" id="3_r3n87"]
+[ext_resource type="AudioStream" uid="uid://cjqacppbmh2tk" path="res://common/audio/sfx/ui/aud_ui_open.wav" id="4_e3nyf"]
+[ext_resource type="Script" uid="uid://bqaasgleubvyc" path="res://components/sound_player_3d/sound_player_3d.gd" id="5_rrvrm"]
+
+[node name="Trin" node_paths=PackedStringArray("sound_player_3d", "signal_node") instance=ExtResource("1_c4qox")]
+script = ExtResource("2_rrvrm")
+sound_player_3d = NodePath("SoundPlayer3D")
+signal_node = NodePath("InteractNotify")
+
+[node name="tweenbase00" parent="." index="0" instance=ExtResource("2_1jpor")]
+
+[node name="Name" parent="." index="1"]
+text = "Trin"
+
+[node name="MeshInstance3D" parent="." index="2"]
+visible = false
+
+[node name="InteractNotify" parent="." index="5" instance=ExtResource("3_r3n87")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+npc_id = "trin"
+
+[node name="Dialogue" parent="." index="6"]
+npc_id = "trin"
+
+[node name="SoundPlayer3D" type="AudioStreamPlayer3D" parent="." index="12" node_paths=PackedStringArray("start_callable_node")]
+stream = ExtResource("4_e3nyf")
+script = ExtResource("5_rrvrm")
+start_callable_node = NodePath("../InteractNotify")
+start_signal_name = &"talked_to"
+metadata/_custom_type_script = "uid://bqaasgleubvyc"
+
+[editable path="tweenbase00"]
+[editable path="InteractableArea3D"]


### PR DESCRIPTION
A 3D sound effect player triggered by an event
- [x] Extends AudioStreamPlayer3D
- [x] designer can add 'SoundEffectPlayer3D' to any scene using "add child node"
- [x] designer can select a node that has signals to subscribe to in the available tree scope
- [x] designer can subscribe the player to an event signal using signal string name
- [x] designer can configure the sound effect to be played
- [x] when 'SoundEffectPlayer3D' receives subscribed signal it emits sound effect
- [x] designer may subscribe the player to an explicit stop signal
- [x] when 'SoundEffectPlayer3D' receives subscribed 'stop' signal the sound effect immediately stops playing