### PR TITLE
Fix Sky Shader Compilation Bug

### DIFF
--- a/components/environment/sky_environment.gdshader
+++ b/components/environment/sky_environment.gdshader
@@ -36,7 +36,7 @@ group_uniforms clouds;
 	uniform vec3 clouds_middle_color : source_color = vec3( 0.92, 0.92, 0.98 );
 	uniform vec3 clouds_bottom_color : source_color = vec3( 0.83, 0.83, 0.94 );
 	uniform float clouds_speed : hint_range( 0.0, 20.0, 0.01 ) = 2.0;
-	uniform float clouds_direction : hint_range( -0.5, 0.5, 0.0 ) = 0.2;
+	uniform float clouds_direction : hint_range( -0.5, 0.5, 0.01 ) = 0.2;
 	uniform float clouds_scale : hint_range( 0.0, 4.0, 0.01 ) = 1.0;
 	uniform float clouds_cutoff : hint_range( 0.0, 1.0, 0.01 ) = 0.3;
 	uniform float clouds_fuzziness : hint_range( 0.0, 2.0, 0.01 ) = 0.5;


### PR DESCRIPTION
The slider step size for clouds_direction was accidently set to 0, which is not allowed, so I set it to 0.01.