### PR TITLE
hover signal for buttons

### DIFF
--- a/common/ui/pause_menu/pause_menu.tscn
+++ b/common/ui/pause_menu/pause_menu.tscn
@@ -107,9 +107,12 @@ layout_mode = 2
 text = "I'm Stuck"
 
 [connection signal="mouse_entered" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/ContinueButton" to="Audio Control" method="_on_hover"]
+[connection signal="mouse_entered" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/DashboardButton" to="Audio Control" method="_on_hover"]
+[connection signal="mouse_entered" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/DashboardButton" to="Audio Control" method="_on_dashboard_button_mouse_entered"]
 [connection signal="mouse_entered" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/OptionsButton" to="Audio Control" method="_on_hover"]
 [connection signal="pressed" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/OptionsButton" to="Audio Control" method="_on_open"]
 [connection signal="mouse_entered" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/MainMenuButton" to="Audio Control" method="_on_hover"]
 [connection signal="pressed" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/MainMenuButton" to="Audio Control" method="_on_close"]
 [connection signal="mouse_entered" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/QuitButton" to="Audio Control" method="_on_hover"]
 [connection signal="pressed" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/QuitButton" to="Audio Control" method="_on_close"]
+[connection signal="mouse_entered" from="PauseMenuBody/PanelContainer/MarginContainer/VBoxContainer/MarginContainer/VBoxContainer/RespawnButton" to="Audio Control" method="_on_hover"]


### PR DESCRIPTION
https://www.notion.so/hexwave/Missing-sound-effects-on-some-buttons-of-Pause-Menu-21ce3beb843f8055bff9ef656b0bb8a2?source=copy_link

Connected the mouse entered event to _on_hover audio system callback. Buttons now play appropriate on hover sound effect.